### PR TITLE
roma/feat/initializer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,12 @@ endif()
 
 # Find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(dua_qos_cpp REQUIRED)
 find_package(params_manager_cpp REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(simple_actionclient_cpp REQUIRED)
+find_package(simple_serviceclient_cpp REQUIRED)
 
 # DUA Node library configuration
 add_library(duanode SHARED
@@ -31,8 +35,12 @@ target_include_directories(duanode PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 ament_target_dependencies(duanode
+  dua_qos_cpp
   params_manager_cpp
-  rclcpp)
+  rclcpp
+  rclcpp_action
+  simple_actionclient_cpp
+  simple_serviceclient_cpp)
 
 # Library installation
 install(
@@ -61,7 +69,11 @@ endif()
 # Export all dependencies and library targets for this package
 ament_export_targets(dua_nodeTargets HAS_LIBRARY_TARGET)
 ament_export_dependencies(
+  dua_qos_cpp
   params_manager_cpp
-  rclcpp)
+  rclcpp
+  rclcpp_action
+  simple_actionclient_cpp
+  simple_serviceclient_cpp)
 
 ament_package()

--- a/include/dua_node_cpp/dua_node.hpp
+++ b/include/dua_node_cpp/dua_node.hpp
@@ -308,7 +308,7 @@ protected:
         feedback_callback,
         wait);
     if (verbose_) {
-      RCLCPP_INFO(get_logger(), "[ACTION CLN] '%s'", get_entity_fqn(action_name).c_str());
+      RCLCPP_INFO(get_logger(), "[ACTION CLN] '%s'", client->get_action_name().c_str());
     }
     return client;
   }

--- a/include/dua_node_cpp/dua_node.hpp
+++ b/include/dua_node_cpp/dua_node.hpp
@@ -26,11 +26,19 @@
 
 #include "visibility_control.h"
 
+#include <chrono>
 #include <memory>
+#include <string>
 
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+
+#include <dua_qos_cpp/dua_qos.hpp>
 
 #include <params_manager_cpp/params_manager.hpp>
+
+#include <simple_actionclient_cpp/simple_actionclient.hpp>
+#include <simple_serviceclient_cpp/simple_serviceclient.hpp>
 
 namespace dua_node
 {
@@ -52,8 +60,10 @@ public:
    *
    * @param node_name Name of the node.
    * @param opts Node options.
+   * @param verbose Verbosity flag.
    */
-  NodeBase(std::string && node_name,
+  NodeBase(
+    std::string && node_name,
     const rclcpp::NodeOptions & opts = rclcpp::NodeOptions(),
     bool verbose = false);
 
@@ -80,7 +90,248 @@ protected:
   /**
    * @brief Initializes the node calling internal initializers.
    */
-  void init_node();
+  void dua_init_node();
+
+  /**
+   * @brief Wraps creation of a timer.
+   *        This observes the ROS clock, be it system time or externally supplied.
+   *
+   * @param name Timer name.
+   * @param period Timer period [ms].
+   * @param callback Timer callback.
+   * @param timer_group Timer callback group.
+   * @return Timer shared pointer.
+   */
+  template<typename CallbackT>
+  rclcpp::TimerBase::SharedPtr dua_create_timer(
+    const std::string & name,
+    unsigned long int period,
+    CallbackT callback,
+    rclcpp::CallbackGroup::SharedPtr timer_cgroup = nullptr)
+  {
+    rclcpp::TimerBase::SharedPtr timer = create_timer(
+      std::chrono::milliseconds(period),
+      callback,
+      timer_cgroup);
+    if (verbose_) {
+      RCLCPP_INFO(get_logger(), "[TIMER] '%s' (%ld ms)", name.c_str(), period);
+    }
+    return timer;
+  }
+
+  /**
+   * @brief Wraps creation of a wall timer.
+   *        This observes the system clock.
+   *
+   * @param name Timer name.
+   * @param period Timer period [ms].
+   * @param callback Timer callback.
+   * @param timer_group Timer callback group.
+   * @return Timer shared pointer.
+   */
+  template<typename CallbackT>
+  rclcpp::TimerBase::SharedPtr dua_create_wall_timer(
+    const std::string & name,
+    unsigned long int period,
+    CallbackT callback,
+    rclcpp::CallbackGroup::SharedPtr timer_cgroup = nullptr)
+  {
+    rclcpp::TimerBase::SharedPtr timer = create_wall_timer(
+      std::chrono::milliseconds(period),
+      callback,
+      timer_cgroup);
+    if (verbose_) {
+      RCLCPP_INFO(get_logger(), "[WALL TIMER] '%s' (%ld ms)", name.c_str(), period);
+    }
+    return timer;
+  }
+
+  /**
+   * @brief Wraps the creation of a subscriber.
+   *
+   * @param topic_name Topic name.
+   * @param callback Subscriber callback.
+   * @param qos Quality of Service policy.
+   * @param sub_cgroup Subscriber callback group.
+   * @return Subscriber shared pointer.
+   */
+  template<typename MessageT, typename CallbackT>
+  typename rclcpp::Subscription<MessageT>::SharedPtr dua_create_subscription(
+    const std::string & topic_name,
+    CallbackT && callback,
+    const rclcpp::QoS & qos = dua_qos::Reliable::get_datum_qos(),
+    rclcpp::CallbackGroup::SharedPtr sub_cgroup = nullptr)
+  {
+    typename rclcpp::Subscription<MessageT>::SharedPtr sub = nullptr;
+    if (sub_cgroup != nullptr) {
+      rclcpp::SubscriptionOptions opts;
+      opts.callback_group = sub_cgroup;
+      sub = create_subscription<MessageT>(
+        topic_name,
+        qos,
+        std::forward<CallbackT>(callback),
+        opts);
+    } else {
+      sub = create_subscription<MessageT>(
+        topic_name,
+        qos,
+        std::forward<CallbackT>(callback));
+    }
+    if (verbose_) {
+      RCLCPP_INFO(get_logger(), "[TOPIC SUB] '%s'", sub->get_topic_name());
+    }
+    return sub;
+  }
+
+  /**
+   * @brief Wraps the creation of a publisher.
+   *
+   * @param topic_name Topic name.
+   * @param qos Quality of Service policy.
+   * @return Publisher shared pointer.
+   */
+  template<typename MessageT>
+  typename rclcpp::Publisher<MessageT>::SharedPtr dua_create_publisher(
+    const std::string & topic_name,
+    const rclcpp::QoS & qos = dua_qos::Reliable::get_datum_qos())
+  {
+    typename rclcpp::Publisher<MessageT>::SharedPtr pub =
+      create_publisher<MessageT>(topic_name, qos);
+    if (verbose_) {
+      RCLCPP_INFO(get_logger(), "[TOPIC PUB] '%s'", pub->get_topic_name());
+    }
+    return pub;
+  }
+
+  /**
+   * @brief Wraps the creation of a service server.
+   *
+   * @param service_name Service name.
+   * @param callback Service callback.
+   * @param srv_cgroup Service callback group.
+   * @return Service server shared pointer.
+   */
+  template<typename ServiceT, typename CallbackT>
+  typename rclcpp::Service<ServiceT>::SharedPtr dua_create_service_server(
+    const std::string & service_name,
+    CallbackT && callback,
+    rclcpp::CallbackGroup::SharedPtr srv_cgroup = nullptr)
+  {
+    typename rclcpp::Service<ServiceT>::SharedPtr server = create_service<ServiceT>(
+      service_name,
+      std::forward<CallbackT>(callback),
+      rclcpp::ServicesQoS(),
+      srv_cgroup);
+    if (verbose_) {
+      RCLCPP_INFO(get_logger(), "[SERVICE SRV] '%s'", server->get_service_name());
+    }
+    return server;
+  }
+
+  /**
+   * @brief Wraps the creation of a service client.
+   *        This purposely uses the simple_serviceclient::Client implementation.
+   *
+   * @param service_name Service name.
+   * @param wait Whether to wait for the server to become active.
+   * @return Service client shared pointer.
+   */
+  template<typename ServiceT>
+  typename simple_serviceclient::Client<ServiceT>::SharedPtr dua_create_service_client(
+    const std::string & service_name,
+    bool wait = true)
+  {
+    typename simple_serviceclient::Client<ServiceT>::SharedPtr client =
+      std::make_shared<simple_serviceclient::Client<ServiceT>>(
+        this,
+        service_name,
+        wait);
+    if (verbose_) {
+      RCLCPP_INFO(get_logger(), "[SERVICE CLN] '%s'", client->get_service_name());
+    }
+    return client;
+  }
+
+  /**
+   * @brief Wraps the creation of an action server.
+   *        Callbacks must always be provided to this.
+   *
+   * @param action_name Action name.
+   * @param goal_callback Goal callback.
+   * @param cancel_callback Cancel callback.
+   * @param accepted_callback Accepted callback.
+   * @param as_cgroup Action server callback group.
+   * @return Action server shared pointer.
+   */
+  template<typename ActionT, typename GoalCallbackT, typename CancelCallbackT, typename AcceptedCallbackT>
+  typename rclcpp_action::Server<ActionT>::SharedPtr dua_create_action_server(
+    const std::string & action_name,
+    GoalCallbackT && goal_callback,
+    CancelCallbackT && cancel_callback,
+    AcceptedCallbackT && accepted_callback,
+    rclcpp::CallbackGroup::SharedPtr as_cgroup = nullptr)
+  {
+    typename rclcpp_action::Server<ActionT>::SharedPtr server =
+      rclcpp_action::create_server<ActionT>(
+        this,
+        action_name,
+        std::forward<GoalCallbackT>(goal_callback),
+        std::forward<CancelCallbackT>(cancel_callback),
+        std::forward<AcceptedCallbackT>(accepted_callback),
+        dua_qos::get_action_server_options(),
+        as_cgroup);
+    if (verbose_) {
+      RCLCPP_INFO(get_logger(), "[ACTION SRV] '%s'", get_entity_fqn(action_name).c_str());
+    }
+    return server;
+  }
+
+  /**
+   * @brief Wraps the creation of an action client.
+   *        This purposely uses the simple_actionclient::Client implementation.
+   *
+   * @param action_name Action name.
+   * @param feedback_callback Feedback callback.
+   * @param wait Whether to wait for the server to become active.
+   * @return Action client shared pointer.
+   */
+  template<typename ActionT>
+  typename simple_actionclient::Client<ActionT>::SharedPtr dua_create_action_client(
+    const std::string & action_name,
+    const simple_actionclient::FeedbackCallbackT<ActionT> & feedback_callback = nullptr,
+    bool wait = true)
+  {
+    typename simple_actionclient::Client<ActionT>::SharedPtr client =
+      std::make_shared<simple_actionclient::Client<ActionT>>(
+        this,
+        action_name,
+        feedback_callback,
+        wait);
+    if (verbose_) {
+      RCLCPP_INFO(get_logger(), "[ACTION CLN] '%s'", get_entity_fqn(action_name).c_str());
+    }
+    return client;
+  }
+
+  /**
+   * @brief Returns a mutually exclusive callback group.
+   *
+   * @return Callback group shared pointer.
+   */
+  inline rclcpp::CallbackGroup::SharedPtr dua_create_exclusive_cgroup()
+  {
+    return create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  }
+
+  /**
+   * @brief Returns a reentrant callback group.
+   *
+   * @return Callback group shared pointer.
+   */
+  inline rclcpp::CallbackGroup::SharedPtr dua_create_reentrant_cgroup()
+  {
+    return create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+  }
 
   /**
    * @brief Initializes the node parameters (must be overridden).
@@ -140,53 +391,61 @@ protected:
   params_manager::Manager::SharedPtr pmanager_;
 
 private:
-    /**
-     * @brief Initializes node parameters.
-     */
-    void dua_init_parameters();
+  /**
+   * @brief Initializes node parameters.
+   */
+  void dua_init_parameters();
 
-    /**
-     * @brief Initializes callback groups.
-     */
-    void dua_init_cgroups();
+  /**
+   * @brief Initializes callback groups.
+   */
+  void dua_init_cgroups();
 
-    /**
-     * @brief Initializes timers.
-     */
-    void dua_init_timers();
+  /**
+   * @brief Initializes timers.
+   */
+  void dua_init_timers();
 
-    /**
-     * @brief Initializes subscribers.
-     */
-    void dua_init_subscribers();
+  /**
+   * @brief Initializes subscribers.
+   */
+  void dua_init_subscribers();
 
-    /**
-     * @brief Initializes publishers.
-     */
-    void dua_init_publishers();
+  /**
+   * @brief Initializes publishers.
+   */
+  void dua_init_publishers();
 
-    /**
-     * @brief Initializes service servers.
-     */
-    void dua_init_service_servers();
+  /**
+   * @brief Initializes service servers.
+   */
+  void dua_init_service_servers();
 
-    /**
-     * @brief Initializes service clients.
-     */
-    void dua_init_service_clients();
+  /**
+   * @brief Initializes service clients.
+   */
+  void dua_init_service_clients();
 
-    /**
-     * @brief Initializes actions servers.
-     */
-    void dua_init_action_servers();
+  /**
+   * @brief Initializes actions servers.
+   */
+  void dua_init_action_servers();
 
-    /**
-     * @brief Initializes actions clients.
-     */
-    void dua_init_action_clients();
+  /**
+   * @brief Initializes actions clients.
+   */
+  void dua_init_action_clients();
 
-    /* Verbosity flag. */
-    bool verbose_ = false;
+  /**
+   * @brief Returns the fully qualified name of an entity.
+   *
+   * @param entity_name Entity name.
+   * @return Fully qualified name, may start with a '~'.
+   */
+  std::string get_entity_fqn(std::string entity_name);
+
+  /* Verbosity flag. */
+  bool verbose_ = false;
 };
 
 } // namespace dua_node

--- a/include/dua_node_cpp/dua_node.hpp
+++ b/include/dua_node_cpp/dua_node.hpp
@@ -22,8 +22,7 @@
  * limitations under the License.
  */
 
-#ifndef DUA_NODE__DUA_NODE_HPP_
-#define DUA_NODE__DUA_NODE_HPP_
+#pragma once
 
 #include "visibility_control.h"
 
@@ -78,10 +77,116 @@ public:
   NodeBase::ConstSharedPtr shared_from_this() const;
 
 protected:
+  /**
+   * @brief Initializes the node calling internal initializers.
+   */
+  void init_node();
+
+  /**
+   * @brief Initializes the node parameters (must be overridden).
+   */
+  virtual void init_parameters()
+  {}
+
+  /**
+   * @brief Initializes the node callback groups (must be overridden).
+   */
+  virtual void init_cgroups()
+  {}
+
+  /**
+   * @brief Initializes the node timers (must be overridden).
+   */
+  virtual void init_timers()
+  {}
+
+  /**
+   * @brief Initializes the node subscribers (must be overridden).
+   */
+  virtual void init_subscribers()
+  {}
+
+  /**
+   * @brief Initializes the node publishers (must be overridden).
+   */
+  virtual void init_publishers()
+  {}
+
+  /**
+   * @brief Initializes the node service servers (must be overridden).
+   */
+  virtual void init_service_servers()
+  {}
+
+  /**
+   * @brief Initializes the node service clients (must be overridden).
+   */
+  virtual void init_service_clients()
+  {}
+
+  /**
+   * @brief Initializes the node action servers (must be overridden).
+   */
+  virtual void init_action_servers()
+  {}
+
+  /**
+   * @brief Initializes the node action clients (must be overridden).
+   */
+  virtual void init_action_clients()
+  {}
+
   /* Parameter manager object. */
   params_manager::Manager::SharedPtr pmanager_;
+
+private:
+    /**
+     * @brief Initializes node parameters.
+     */
+    void dua_init_parameters();
+
+    /**
+     * @brief Initializes callback groups.
+     */
+    void dua_init_cgroups();
+
+    /**
+     * @brief Initializes timers.
+     */
+    void dua_init_timers();
+
+    /**
+     * @brief Initializes subscribers.
+     */
+    void dua_init_subscribers();
+
+    /**
+     * @brief Initializes publishers.
+     */
+    void dua_init_publishers();
+
+    /**
+     * @brief Initializes service servers.
+     */
+    void dua_init_service_servers();
+
+    /**
+     * @brief Initializes service clients.
+     */
+    void dua_init_service_clients();
+
+    /**
+     * @brief Initializes actions servers.
+     */
+    void dua_init_action_servers();
+
+    /**
+     * @brief Initializes actions clients.
+     */
+    void dua_init_action_clients();
+
+    /* Verbosity flag. */
+    bool verbose_ = false;
 };
 
 } // namespace dua_node
-
-#endif // DUA_NODE__DUA_NODE_HPP_

--- a/package.xml
+++ b/package.xml
@@ -10,8 +10,12 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <depend>dua_qos_cpp</depend>
   <depend>params_manager_cpp</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_actions</depend>
+  <depend>simple_actionclient_cpp</depend>
+  <depend>simple_serviceclient_cpp</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dua_node_cpp</name>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
   <description>ROS 2 node base classes with DUA extensions.</description>
   <maintainer email="info@dotxautomation.com">dotX Automation s.r.l.</maintainer>
   <license>Apache-2.0</license>

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dua_node_cpp</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>ROS 2 node base classes with DUA extensions.</description>
   <maintainer email="info@dotxautomation.com">dotX Automation s.r.l.</maintainer>
   <license>Apache-2.0</license>

--- a/src/dua_node.cpp
+++ b/src/dua_node.cpp
@@ -44,7 +44,7 @@ NodeBase::~NodeBase()
   pmanager_.reset();
 }
 
-void NodeBase::init_node()
+void NodeBase::dua_init_node()
 {
   dua_init_parameters();
   dua_init_cgroups();
@@ -60,7 +60,7 @@ void NodeBase::init_node()
 void NodeBase::dua_init_parameters()
 {
   if (verbose_) {
-    RCLCPP_INFO(get_logger(), "Parameters:");
+    RCLCPP_INFO(get_logger(), "--- PARAMETERS ---");
   }
   init_parameters();
 }
@@ -73,7 +73,7 @@ void NodeBase::dua_init_cgroups()
 void NodeBase::dua_init_timers()
 {
   if (verbose_) {
-    RCLCPP_INFO(get_logger(), "Timers:");
+    RCLCPP_INFO(get_logger(), "--- TIMERS ---");
   }
   init_timers();
 }
@@ -81,7 +81,7 @@ void NodeBase::dua_init_timers()
 void NodeBase::dua_init_subscribers()
 {
   if (verbose_) {
-    RCLCPP_INFO(get_logger(), "Subscribers:");
+    RCLCPP_INFO(get_logger(), "--- SUBSCRIBERS ---");
   }
   init_subscribers();
 }
@@ -89,7 +89,7 @@ void NodeBase::dua_init_subscribers()
 void NodeBase::dua_init_publishers()
 {
   if (verbose_) {
-    RCLCPP_INFO(get_logger(), "Publishers:");
+    RCLCPP_INFO(get_logger(), "--- PUBLISHERS ---");
   }
   init_publishers();
 }
@@ -97,7 +97,7 @@ void NodeBase::dua_init_publishers()
 void NodeBase::dua_init_service_servers()
 {
   if (verbose_) {
-    RCLCPP_INFO(get_logger(), "Service servers:");
+    RCLCPP_INFO(get_logger(), "--- SERVICE SERVERS ---");
   }
   init_service_servers();
 }
@@ -105,7 +105,7 @@ void NodeBase::dua_init_service_servers()
 void NodeBase::dua_init_service_clients()
 {
   if (verbose_) {
-    RCLCPP_INFO(get_logger(), "Service clients:");
+    RCLCPP_INFO(get_logger(), "--- SERVICE CLIENTS ---");
   }
   init_service_clients();
 }
@@ -113,7 +113,7 @@ void NodeBase::dua_init_service_clients()
 void NodeBase::dua_init_action_servers()
 {
   if (verbose_) {
-    RCLCPP_INFO(get_logger(), "Action servers:");
+    RCLCPP_INFO(get_logger(), "--- ACTION SERVERS ---");
   }
   init_action_servers();
 }
@@ -121,9 +121,19 @@ void NodeBase::dua_init_action_servers()
 void NodeBase::dua_init_action_clients()
 {
   if (verbose_) {
-    RCLCPP_INFO(get_logger(), "Action clients:");
+    RCLCPP_INFO(get_logger(), "--- ACTION CLIENTS ---");
   }
   init_action_clients();
+}
+
+std::string NodeBase::get_entity_fqn(std::string entity_name)
+{
+  std::string ns = std::string(get_fully_qualified_name());
+  size_t pos = entity_name.find_last_of("/");
+  if (pos != std::string::npos) {
+    entity_name = entity_name.substr(pos + 1);
+  }
+  return ns + "/" + entity_name;
 }
 
 NodeBase::SharedPtr NodeBase::shared_from_this()

--- a/src/dua_node.cpp
+++ b/src/dua_node.cpp
@@ -31,7 +31,8 @@ NodeBase::NodeBase(
   std::string && node_name,
   const rclcpp::NodeOptions & opts,
   bool verbose)
-: Node(node_name, opts)
+: Node(node_name, opts),
+  verbose_(verbose)
 {
   // Create and initialize Parameter Manager object
   pmanager_ = std::make_shared<params_manager::Manager>(this, verbose);
@@ -41,6 +42,88 @@ NodeBase::~NodeBase()
 {
   // Destroy Parameter Manager object
   pmanager_.reset();
+}
+
+void NodeBase::init_node()
+{
+  dua_init_parameters();
+  dua_init_cgroups();
+  dua_init_timers();
+  dua_init_subscribers();
+  dua_init_publishers();
+  dua_init_service_servers();
+  dua_init_service_clients();
+  dua_init_action_servers();
+  dua_init_action_clients();
+}
+
+void NodeBase::dua_init_parameters()
+{
+  if (verbose_) {
+    RCLCPP_INFO(get_logger(), "Parameters:");
+  }
+  init_parameters();
+}
+
+void NodeBase::dua_init_cgroups()
+{
+  init_cgroups();
+}
+
+void NodeBase::dua_init_timers()
+{
+  if (verbose_) {
+    RCLCPP_INFO(get_logger(), "Timers:");
+  }
+  init_timers();
+}
+
+void NodeBase::dua_init_subscribers()
+{
+  if (verbose_) {
+    RCLCPP_INFO(get_logger(), "Subscribers:");
+  }
+  init_subscribers();
+}
+
+void NodeBase::dua_init_publishers()
+{
+  if (verbose_) {
+    RCLCPP_INFO(get_logger(), "Publishers:");
+  }
+  init_publishers();
+}
+
+void NodeBase::dua_init_service_servers()
+{
+  if (verbose_) {
+    RCLCPP_INFO(get_logger(), "Service servers:");
+  }
+  init_service_servers();
+}
+
+void NodeBase::dua_init_service_clients()
+{
+  if (verbose_) {
+    RCLCPP_INFO(get_logger(), "Service clients:");
+  }
+  init_service_clients();
+}
+
+void NodeBase::dua_init_action_servers()
+{
+  if (verbose_) {
+    RCLCPP_INFO(get_logger(), "Action servers:");
+  }
+  init_action_servers();
+}
+
+void NodeBase::dua_init_action_clients()
+{
+  if (verbose_) {
+    RCLCPP_INFO(get_logger(), "Action clients:");
+  }
+  init_action_clients();
 }
 
 NodeBase::SharedPtr NodeBase::shared_from_this()


### PR DESCRIPTION
- Initializers for automated node initialization.
- ROS 2 entity creator methods, integrating our wrappers where possible.
- Integrated support for dua_qos_cpp, simple_actionclient, simple_serviceclient.
- Enforcing of standard node structure is now automated.
- Dependencies are automatically propagated through ament, _i.e._ one only has to include/depend/find dua_node_cpp.