### PR TITLE
feat: dua_tf_server support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,16 @@ endif()
 
 # Find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(dua_common_interfaces REQUIRED)
+find_package(dua_geometry_interfaces REQUIRED)
 find_package(dua_qos_cpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(params_manager_cpp REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(simple_actionclient_cpp REQUIRED)
 find_package(simple_serviceclient_cpp REQUIRED)
+find_package(std_msgs REQUIRED)
 
 # DUA Node library configuration
 add_library(duanode SHARED src/dua_node.cpp)
@@ -35,12 +39,16 @@ target_include_directories(duanode PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 ament_target_dependencies(duanode
+  dua_common_interfaces
+  dua_geometry_interfaces
   dua_qos_cpp
+  geometry_msgs
   params_manager_cpp
   rclcpp
   rclcpp_action
   simple_actionclient_cpp
-  simple_serviceclient_cpp)
+  simple_serviceclient_cpp
+  std_msgs)
 
 # Library installation
 install(
@@ -69,11 +77,15 @@ endif()
 # Export all dependencies and library targets for this package
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
+  dua_common_interfaces
+  dua_geometry_interfaces
   dua_qos_cpp
+  geometry_msgs
   params_manager_cpp
   rclcpp
   rclcpp_action
   simple_actionclient_cpp
-  simple_serviceclient_cpp)
+  simple_serviceclient_cpp
+  std_msgs)
 
 ament_package()

--- a/include/dua_node_cpp/dua_node.hpp
+++ b/include/dua_node_cpp/dua_node.hpp
@@ -28,6 +28,7 @@
 
 #include <chrono>
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 #include <rclcpp/rclcpp.hpp>
@@ -39,6 +40,13 @@
 
 #include <simple_actionclient_cpp/simple_actionclient.hpp>
 #include <simple_serviceclient_cpp/simple_serviceclient.hpp>
+
+#include <dua_common_interfaces/msg/command_result_stamped.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <std_msgs/msg/header.hpp>
+
+#include <dua_geometry_interfaces/srv/get_transform.hpp>
+#include <dua_geometry_interfaces/srv/transform_pose.hpp>
 
 namespace dua_node
 {
@@ -429,8 +437,56 @@ protected:
   virtual void init_action_clients()
   {}
 
+  /**
+   * @brief Requests a transform between two frames.
+   *
+   * @param source Source frame ID and timestamp.
+   * @param target Target frame ID and timestamp.
+   * @param transform Output transform.
+   * @param transform_frames Whether to output the transformation between frames or coordinates.
+   * @param timeout TF lookup timeout.
+   * @param spin Whether to spin the node while waiting for the response.
+   * @param srv_timeout Service call timeout [ms].
+   *
+   * @return True on success, false on failure.
+   * @throws std::runtime_error if the service client is not initialized.
+   */
+  bool get_transform(
+    const std_msgs::msg::Header & source,
+    const std_msgs::msg::Header & target,
+    geometry_msgs::msg::TransformStamped & transform,
+    bool transform_frames = false,
+    const rclcpp::Duration & timeout = rclcpp::Duration::from_seconds(1.0),
+    bool spin = false,
+    int64_t srv_timeout = 0L);
+
+  /**
+   * @brief Requests the transformation of a given Pose from one frame to another.
+   *
+   * @param source_pose Pose to transform.
+   * @param target Target frame ID and timestamp.
+   * @param target_pose Output transformed Pose.
+   * @param timeout TF lookup timeout.
+   * @param spin Whether to spin the node while waiting for the response.
+   * @param srv_timeout Service call timeout [ms].
+   *
+   * @return True on success, false on failure.
+   * @throws std::runtime_error if the service client is not initialized.
+   */
+  bool transform_pose(
+    const geometry_msgs::msg::PoseStamped & source_pose,
+    const std_msgs::msg::Header & target,
+    geometry_msgs::msg::PoseStamped & target_pose,
+    const rclcpp::Duration & timeout = rclcpp::Duration::from_seconds(1.0),
+    bool spin = false,
+    int64_t srv_timeout = 0L);
+
   /* Parameter manager object. */
   params_manager::Manager::SharedPtr pmanager_;
+
+  /* Service clients. */
+  simple_serviceclient::Client<dua_geometry_interfaces::srv::GetTransform>::SharedPtr get_transform_client_ = nullptr;
+  simple_serviceclient::Client<dua_geometry_interfaces::srv::TransformPose>::SharedPtr transform_pose_client_ = nullptr;
 
 private:
   /**
@@ -488,6 +544,11 @@ private:
 
   /* Verbosity flag. */
   bool verbose_ = false;
+
+  /* Internal node parameters. */
+  bool tf_server_get_transform_ = false;
+  bool tf_server_transform_pose_ = false;
+  bool tf_server_wait_servers_ = false;
 };
 
 } // namespace dua_node

--- a/include/dua_node_cpp/dua_node.hpp
+++ b/include/dua_node_cpp/dua_node.hpp
@@ -27,6 +27,7 @@
 #include "visibility_control.h"
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -449,10 +450,10 @@ protected:
    * @param spin Whether to spin the node while waiting for the response.
    * @param srv_timeout Service call timeout [ms].
    *
-   * @return True on success, false on failure.
+   * @return 0 if the server did not respond, else the CommandResultStamped code.
    * @throws std::runtime_error if the service client is not initialized.
    */
-  bool get_transform(
+  uint8_t get_transform(
     const std_msgs::msg::Header & source,
     const std_msgs::msg::Header & target,
     geometry_msgs::msg::TransformStamped & transform,
@@ -471,10 +472,10 @@ protected:
    * @param spin Whether to spin the node while waiting for the response.
    * @param srv_timeout Service call timeout [ms].
    *
-   * @return True on success, false on failure.
+   * @return 0 if the server did not respond, else the CommandResultStamped code.
    * @throws std::runtime_error if the service client is not initialized.
    */
-  bool transform_pose(
+  uint8_t transform_pose(
     const geometry_msgs::msg::PoseStamped & source_pose,
     const std_msgs::msg::Header & target,
     geometry_msgs::msg::PoseStamped & target_pose,

--- a/include/dua_node_cpp/dua_node.hpp
+++ b/include/dua_node_cpp/dua_node.hpp
@@ -43,6 +43,7 @@
 
 #include <dua_common_interfaces/msg/command_result_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
 #include <std_msgs/msg/header.hpp>
 
 #include <dua_geometry_interfaces/srv/get_transform.hpp>

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dua_node_cpp</name>
-  <version>1.1.6</version>
+  <version>1.2.0</version>
   <description>ROS 2 node base classes with DUA extensions.</description>
   <maintainer email="info@dotxautomation.com">dotX Automation s.r.l.</maintainer>
   <license>Apache-2.0</license>
@@ -10,12 +10,16 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <depend>dua_common_interfaces</depend>
+  <depend>dua_geometry_interfaces</depend>
   <depend>dua_qos_cpp</depend>
+  <depend>geometry_msgs</depend>
   <depend>params_manager_cpp</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_actions</depend>
   <depend>simple_actionclient_cpp</depend>
   <depend>simple_serviceclient_cpp</depend>
+  <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/dua_node.cpp
+++ b/src/dua_node.cpp
@@ -203,7 +203,7 @@ uint8_t NodeBase::get_transform(
       "GetTransform call error ('%s' -> '%s'): no response",
       source.frame_id.c_str(),
       target.frame_id.c_str());
-    return 0;
+    return dua_common_interfaces::msg::CommandResultStamped::TIMEOUT;
   }
   if (resp->result.result == dua_common_interfaces::msg::CommandResultStamped::ERROR) {
     RCLCPP_ERROR_THROTTLE(
@@ -249,7 +249,7 @@ uint8_t NodeBase::transform_pose(
       "TransformPose call error ('%s' -> '%s'): no response",
       source_pose.header.frame_id.c_str(),
       target.frame_id.c_str());
-    return 0;
+    return dua_common_interfaces::msg::CommandResultStamped::TIMEOUT;
   }
   if (resp->result.result == dua_common_interfaces::msg::CommandResultStamped::ERROR) {
     RCLCPP_ERROR_THROTTLE(

--- a/src/dua_node.cpp
+++ b/src/dua_node.cpp
@@ -168,7 +168,7 @@ void NodeBase::dua_init_action_clients()
   init_action_clients();
 }
 
-bool NodeBase::get_transform(
+uint8_t NodeBase::get_transform(
   const std_msgs::msg::Header & source,
   const std_msgs::msg::Header & target,
   geometry_msgs::msg::TransformStamped & transform,
@@ -203,7 +203,7 @@ bool NodeBase::get_transform(
       "GetTransform call error ('%s' -> '%s'): no response",
       source.frame_id.c_str(),
       target.frame_id.c_str());
-    return false;
+    return 0;
   }
   if (resp->result.result == dua_common_interfaces::msg::CommandResultStamped::ERROR) {
     RCLCPP_ERROR_THROTTLE(
@@ -212,16 +212,15 @@ bool NodeBase::get_transform(
       source.frame_id.c_str(),
       target.frame_id.c_str(),
       resp->result.error_msg.c_str());
-    return false;
+    return resp->result.result;
   }
-  // FAILED means that the latest TF has been provided instead, so it's generally ok
 
-  // Return the transform
+  // Return the transform and the operation result
   transform = resp->transform;
-  return true;
+  return resp->result.result;
 }
 
-bool NodeBase::transform_pose(
+uint8_t NodeBase::transform_pose(
   const geometry_msgs::msg::PoseStamped & source_pose,
   const std_msgs::msg::Header & target,
   geometry_msgs::msg::PoseStamped & target_pose,
@@ -250,7 +249,7 @@ bool NodeBase::transform_pose(
       "TransformPose call error ('%s' -> '%s'): no response",
       source_pose.header.frame_id.c_str(),
       target.frame_id.c_str());
-    return false;
+    return 0;
   }
   if (resp->result.result == dua_common_interfaces::msg::CommandResultStamped::ERROR) {
     RCLCPP_ERROR_THROTTLE(
@@ -259,20 +258,12 @@ bool NodeBase::transform_pose(
       source_pose.header.frame_id.c_str(),
       target.frame_id.c_str(),
       resp->result.error_msg.c_str());
-    return false;
-  }
-  if (resp->result.result == dua_common_interfaces::msg::CommandResultStamped::FAILED) {
-    RCLCPP_ERROR_THROTTLE(
-      get_logger(), *get_clock(), 1000,
-      "TransformPose server failure ('%s' -> '%s'): TF not found",
-      source_pose.header.frame_id.c_str(),
-      target.frame_id.c_str());
-    return false;
+    return resp->result.result;
   }
 
   // Return the result
   target_pose = resp->target_pose;
-  return true;
+  return resp->result.result;
 }
 
 std::string NodeBase::get_entity_fqn(std::string entity_name)

--- a/src/dua_node.cpp
+++ b/src/dua_node.cpp
@@ -62,6 +62,31 @@ void NodeBase::dua_init_parameters()
   if (verbose_) {
     RCLCPP_INFO(get_logger(), "--- PARAMETERS ---");
   }
+
+  // Declare TF server parameters
+  pmanager_->declare_bool_parameter(
+    "dua.tf_server.get_transform",
+    false,
+    "Enable GetTransform client, allows use of standard get_transform API.",
+    "Must remap the service name to a compliant, existing service.",
+    true,
+    &tf_server_get_transform_);
+  pmanager_->declare_bool_parameter(
+    "dua.tf_server.transform_pose",
+    false,
+    "Enable TransformPose client, allows use of standard transform_pose API.",
+    "Must remap the service name to a compliant, existing service.",
+    true,
+    &tf_server_transform_pose_);
+  pmanager_->declare_bool_parameter(
+    "dua.tf_server.wait_servers",
+    false,
+    "Wait for TF servers to be available during node initialization.",
+    "If enabled, the node initialization will block until the TF servers are available.",
+    true,
+    &tf_server_wait_servers_);
+
+  // Declare the rest of the parameters
   init_parameters();
 }
 
@@ -107,6 +132,23 @@ void NodeBase::dua_init_service_clients()
   if (verbose_) {
     RCLCPP_INFO(get_logger(), "--- SERVICE CLIENTS ---");
   }
+
+  // Initialize TF server clients
+  // get_transform
+  if (tf_server_get_transform_) {
+    get_transform_client_ = dua_create_service_client<dua_geometry_interfaces::srv::GetTransform>(
+      "/get_transform",
+      tf_server_wait_servers_);
+  }
+
+  // transform_pose
+  if (tf_server_transform_pose_) {
+    transform_pose_client_ = dua_create_service_client<dua_geometry_interfaces::srv::TransformPose>(
+      "/transform_pose",
+      tf_server_wait_servers_);
+  }
+
+  // Initialize the rest of the clients
   init_service_clients();
 }
 
@@ -124,6 +166,113 @@ void NodeBase::dua_init_action_clients()
     RCLCPP_INFO(get_logger(), "--- ACTION CLIENTS ---");
   }
   init_action_clients();
+}
+
+bool NodeBase::get_transform(
+  const std_msgs::msg::Header & source,
+  const std_msgs::msg::Header & target,
+  geometry_msgs::msg::TransformStamped & transform,
+  bool transform_frames,
+  const rclcpp::Duration & timeout,
+  bool spin,
+  int64_t srv_timeout)
+{
+  // Consistency check
+  if (get_transform_client_== nullptr) {
+    throw std::runtime_error("dua_node::NodeBase::get_transform: client not initialized");
+  }
+
+  // Create the request
+  auto req = std::make_shared<dua_geometry_interfaces::srv::GetTransform::Request>();
+  if (transform_frames) {
+    req->set__source(target);
+    req->set__target(source);
+  } else {
+    req->set__source(source);
+    req->set__target(target);
+  }
+  req->set__timeout(timeout);
+
+  // Send the request
+  auto resp = get_transform_client_->call_sync(req, spin, srv_timeout);
+
+  // Check the response
+  if (resp == nullptr) {
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "GetTransform call error ('%s' -> '%s'): no response",
+      source.frame_id.c_str(),
+      target.frame_id.c_str());
+    return false;
+  }
+  if (resp->result.result == dua_common_interfaces::msg::CommandResultStamped::ERROR) {
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "GetTransform server error ('%s' -> '%s'): %s",
+      source.frame_id.c_str(),
+      target.frame_id.c_str(),
+      resp->result.error_msg.c_str());
+    return false;
+  }
+  // FAILED means that the latest TF has been provided instead, so it's generally ok
+
+  // Return the transform
+  transform = resp->transform;
+  return true;
+}
+
+bool NodeBase::transform_pose(
+  const geometry_msgs::msg::PoseStamped & source_pose,
+  const std_msgs::msg::Header & target,
+  geometry_msgs::msg::PoseStamped & target_pose,
+  const rclcpp::Duration & timeout,
+  bool spin,
+  int64_t srv_timeout)
+{
+  // Consistency check
+  if (transform_pose_client_ == nullptr) {
+    throw std::runtime_error("dua_node::NodeBase::transform_pose: client not initialized");
+  }
+
+  // Create the request
+  auto req = std::make_shared<dua_geometry_interfaces::srv::TransformPose::Request>();
+  req->set__source_pose(source_pose);
+  req->set__target(target);
+  req->set__timeout(timeout);
+
+  // Send the request
+  auto resp = transform_pose_client_->call_sync(req, spin, srv_timeout);
+
+  // Check the response
+  if (resp == nullptr) {
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "TransformPose call error ('%s' -> '%s'): no response",
+      source_pose.header.frame_id.c_str(),
+      target.frame_id.c_str());
+    return false;
+  }
+  if (resp->result.result == dua_common_interfaces::msg::CommandResultStamped::ERROR) {
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "TransformPose server error ('%s' -> '%s'): %s",
+      source_pose.header.frame_id.c_str(),
+      target.frame_id.c_str(),
+      resp->result.error_msg.c_str());
+    return false;
+  }
+  if (resp->result.result == dua_common_interfaces::msg::CommandResultStamped::FAILED) {
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "TransformPose server failure ('%s' -> '%s'): TF not found",
+      source_pose.header.frame_id.c_str(),
+      target.frame_id.c_str());
+    return false;
+  }
+
+  // Return the result
+  target_pose = resp->target_pose;
+  return true;
 }
 
 std::string NodeBase::get_entity_fqn(std::string entity_name)


### PR DESCRIPTION
This pull request introduces support for TF (transform) service clients to the `dua_node_cpp` package, allowing nodes to request transforms and transform poses between coordinate frames using service calls. The update bumps the package version to `1.2.0`.

**TF Service Client Support:**

* Added two new methods to `NodeBase` (`get_transform` and `transform_pose`) for requesting transforms and transforming poses via service clients, with full documentation and error handling. [[1]](diffhunk://#diff-2587a3790a12b45ff01f3d18e13e3cc562e361731378889267cd0f63543c99f4R440-R490) [[2]](diffhunk://#diff-0c1275c8f8cffebe38e87578adc8c85c8cf069e2e2f6a523fae00fd952481158R171-R277)
* Introduced service client member variables for `GetTransform` and `TransformPose` services, and logic to initialize them based on new parameters. [[1]](diffhunk://#diff-2587a3790a12b45ff01f3d18e13e3cc562e361731378889267cd0f63543c99f4R440-R490) [[2]](diffhunk://#diff-0c1275c8f8cffebe38e87578adc8c85c8cf069e2e2f6a523fae00fd952481158R135-R151)
* Added three new parameters (`dua.tf_server.get_transform`, `dua.tf_server.transform_pose`, `dua.tf_server.wait_servers`) to control TF service client behavior and initialization. These are standard for every node which inherits from this class and must be configured to selectively enable these features, which are disabled by default.[[1]](diffhunk://#diff-0c1275c8f8cffebe38e87578adc8c85c8cf069e2e2f6a523fae00fd952481158R65-R89) [[2]](diffhunk://#diff-2587a3790a12b45ff01f3d18e13e3cc562e361731378889267cd0f63543c99f4R547-R551)

**Dependency and Interface Updates:**

* Declared new dependencies on `dua_common_interfaces`, `dua_geometry_interfaces`, `geometry_msgs`, and `std_msgs` in both `CMakeLists.txt` and `package.xml`, and included their headers where needed. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR22-R31) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR42-R51) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR80-R89) [[4]](diffhunk://#diff-37a67ff78eb7260214b323353263b9af40a2fa98719a1e81937fae0159df87a3L5-R22) [[5]](diffhunk://#diff-2587a3790a12b45ff01f3d18e13e3cc562e361731378889267cd0f63543c99f4R31) [[6]](diffhunk://#diff-2587a3790a12b45ff01f3d18e13e3cc562e361731378889267cd0f63543c99f4R44-R50)